### PR TITLE
Update ArcESUEnabled.ps1

### DIFF
--- a/ArcESUEnabled.ps1
+++ b/ArcESUEnabled.ps1
@@ -44,7 +44,7 @@ function Test-ESUEnrollment {
     }
 
     $esuDocument = Get-ESUDocument -ESUSignedDocument $esuSignedDocument;
-    if((Get-Date $esuDocument.timeStamp.expiresOn) -lt (Get-Date))
+    if(([Datetime]$esuDocument.timeStamp.expiresOn) -lt (Get-Date))
     {
         Write-Verbose 'Extended Security Update License is expired.';
         return $false;


### PR DESCRIPTION
This script doesn't run correctly in my Japanese environment. Because Get-Date can't convert the value of json to the correct date.
[Datetime] can do it.

```powershell
$json.timeStamp.expiresOn
Get-Date $json.timeStamp.expiresOn
[Datetime]$json.timeStamp.expiresOn

11/09/23 16:10:03 +00:00

2011年9月24日 1:10:03
2023年11月10日 1:10:03
```