### PR TITLE
Change default OSVersion to 2022-datacenter.

### DIFF
--- a/InstallArcForServerWithToken/azuredeployarcvm.json
+++ b/InstallArcForServerWithToken/azuredeployarcvm.json
@@ -74,7 +74,7 @@
         },
         "OSVersion": {
         "type": "string",
-        "defaultValue": "2022-datacenter-azure-edition",
+        "defaultValue": "2022-datacenter",
         "allowedValues": [
             "2016-datacenter-gensecond",
             "2016-datacenter-server-core-g2",


### PR DESCRIPTION
Change the defaults OSVersion to 2022-datacenter. The current default is 2022 Datacenter Azure Edition. Changing this default for 2 reasons:
1. Needed for Bug Bash
2. Azure Edition isn't a representative case for Arc machines